### PR TITLE
Use of FQCN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,530 @@
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+# Created by https://www.toptal.com/developers/gitignore/api/windows,visualstudiocode,vagrant,pycharm+iml,pycharm+all,pycharm,macos,linux,intellij+iml,intellij+all,intellij,ansible
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows,visualstudiocode,vagrant,pycharm+iml,pycharm+all,pycharm,macos,linux,intellij+iml,intellij+all,intellij,ansible
+
+### Ansible ###
+*.retry
+/.ansible
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+.idea/**/azureSettings.xml
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# AWS User-specific
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# SonarLint plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### Intellij+iml ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# AWS User-specific
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# SonarLint plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### Intellij+iml Patch ###
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# AWS User-specific
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# SonarLint plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+
+# Azure Toolkit for IntelliJ plugin
+# https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
+
+### PyCharm+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# AWS User-specific
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# SonarLint plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### PyCharm+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+
+
+### PyCharm+iml ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+
+# AWS User-specific
+
+# Generated files
+
+# Sensitive or high-churn files
+
+# Gradle
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+
+# Mongo Explorer plugin
+
+# File-based project format
+
+# IntelliJ
+
+# mpeltonen/sbt-idea plugin
+
+# JIRA plugin
+
+# Cursive Clojure plugin
+
+# SonarLint plugin
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+
+# Editor-based Rest Client
+
+# Android studio 3.1+ serialized cache file
+
+### PyCharm+iml Patch ###
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+
+### Vagrant ###
+# General
+.vagrant/
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.log
+
+### Vagrant Patch ###
+*.box
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows,visualstudiocode,vagrant,pycharm+iml,pycharm+all,pycharm,macos,linux,intellij+iml,intellij+all,intellij,ansible
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 tests/playbook.retry
 tests/.cache
 tests/__pycache__
 .molecule
-.vagrant
 .cache
-*.iml
-.idea/
-*.retry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,156 +1,230 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/redis_role/tree/develop)
 
-# [5.0.0](https://github.com/idealista/redis_role/tree/5.0.0) (2023-12-22)
+## [5.1.0](https://github.com/idealista/redis_role/tree/5.1.0) (2025-02-26)
+
+### Fixed
+
+- *[#117](https://github.com/idealista/redis_role/issues/117) Use of FQCN* @ultraheroe
+- *Edit block tasks structure and set file modes* @ultraheroe
+
+## [5.0.0](https://github.com/idealista/redis_role/tree/5.0.0) (2023-12-22)
+
 ### Added
+
 - *[#106](https://github.com/idealista/redis_role/issues/106) Enable/Disable Authentication for Redis role with single/cluster scenarios* @enricocotti
 
-# [4.1.0](https://github.com/idealista/redis_role/tree/4.1.0) (2023-12-15)
+## [4.1.0](https://github.com/idealista/redis_role/tree/4.1.0) (2023-12-15)
+
 ### Fixed
+
 - *[#106](https://github.com/idealista/redis_role/issues/106) Fix old debian apt problem* @enricocotti
+
 ### Added
+
 - *[#106](https://github.com/idealista/redis_role/issues/106) Enable password Authentication and upgrade Redis to last verison (7.2.3)* @enricocotti
 - *[#106](https://github.com/idealista/redis_role/issues/106) Add support bullseye/bookworm* @enricocotti
 
 ## [4.0.5](https://github.com/idealista/redis_role/tree/4.0.5) (2022-11-07)
+
 ### Fixed
+
 - *[#102](https://github.com/idealista/redis_role/issues/102) Cluster config* @sorobon
 
 
 ## [4.0.4](https://github.com/idealista/redis_role/tree/4.0.4) (2020-12-02)
+
 ### Added
+
 - Upgraded to molecule 3 @blalop
+
 ### Fixed
+
 - *[#67](https://github.com/idealista/redis_role/issues/67) Fix execution of not failing when creating clsuter with unexistent hosts* @pablogcaldito
 - *[#86](https://github.com/idealista/redis_role/issues/86) Fix that yamllint does not ignore the folders that is supposed to ignore* @pablogcaldito
 - *[#91](https://github.com/idealista/redis_role/issues/91) Remove redis user home* @blalop
 
 ## [4.0.3](https://github.com/idealista/redis_role/tree/4.0.3) (2019-11-26)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/4.0.2...4.0.3)
+
 ### Fixed
+
 - *[#82](https://github.com/idealista/redis_role/issues/82) Fix missing notifications to service when changing configs* @frantsao
 
 ## [4.0.2](https://github.com/idealista/redis_role/tree/4.0.2) (2019-10-29)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/4.0.1...4.0.2)
+
 ### Added
+
 - *[#78](https://github.com/idealista/redis_role/issues/78) Updated molecule configuration to 2.22 version; updated goss version* @frantsao
- 
+
 ## [4.0.1](https://github.com/idealista/redis_role/tree/4.0.1) (2019-10-11)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/4.0.0...4.0.1)
+
 ### Fixed
+
 - Fixed new replica option in Redis 5 cluster; improved molecule tests @frantsao
 
 ## [4.0.0](https://github.com/idealista/redis_role/tree/4.0.0) (2019-10-11)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/3.0.0...4.0.0)
+
 ### Added
+
 - *[#68](https://github.com/idealista/redis_role/issues/68) Adding Redis Cluster specific tests using `CLUSTER INFO` command* @dortegau
 - *[#70](https://github.com/idealista/redis_role/issues/70) Adding version to Redis Ruby Gem installation (works only in redis 3.x/4.x)* @dortegau
 - *[#62](https://github.com/idealista/redis_role/issues/62) Added support for Redis 5* @frantsao
 - *[#72](https://github.com/idealista/redis_role/issues/72) Renamed role @frantsao
 - Improved molecule and travis tests @frantsao
+
 ### Fixed
+
 - Disable permanently THPs @frantsao
 
 ## [3.0.0](https://github.com/idealista/redis_role/tree/3.0.0) (2019-04-03)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.2.0...3.0.0)
+
 ### Fixed
+
 - *[#61](https://github.com/idealista/redis_role/issues/61) Fixing Redis Cluster tests* @dortegau @frantsao
 
 ### Changed
+
 - *[#60](https://github.com/idealista/redis_role/issues/60) 'Make test' is now configured as an optional Ansible Task* @dortegau
 
 ## [2.2.0](https://github.com/idealista/redis_role/tree/2.2.0) (2018-10-23)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.9...2.2.0)
+
 ### Added
+
 - *[#43](https://github.com/idealista/redis_role/issues/43) Playbooks can provide config templates* @jnogol
 
 ### Fixed
+
 - *Fix travis tests* @jnogol
 
 ## [2.1.9](https://github.com/idealista/redis_role/tree/2.1.9) (2018-05-09)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.8...2.1.9)
+
 ### Fixed
+
 - *[#54](https://github.com/idealista/redis_role/issues/54) Enabling support for execute this role under Python 3.x* @dortegau
 
 ## [2.1.8](https://github.com/idealista/redis_role/tree/2.1.8) (2018-05-08)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.7...2.1.8)
+
 ### Fixed
+
 - *[#51](https://github.com/idealista/redis_role/issues/51) Adding build-essential as required library* @dortegau
 
 ## [2.1.7](https://github.com/idealista/redis_role/tree/2.1.7) (2018-04-26)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.6...2.1.7)
+
 ### Fixed
+
 - *[#47](https://github.com/idealista/redis_role/issues/47) When running the role on "localhost" redis cluster is trying to configure 127.0.0.1 instead of the actual IP* @lihiwish
 
 ### Changed
+
 - *[#45](https://github.com/idealista/redis_role/pull/45) Some tests improvements* @jdvr
 
 ## [2.1.6](https://github.com/idealista/redis_role/tree/2.1.6) (2018-03-09)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.5...2.1.6)
+
 ### Fixed
+
 - *[#41](https://github.com/idealista/redis_role/issues/41) Add RuntimeDirectory and fix ExecStop in redis-server.service* @jnogol
 
 ## [2.1.5](https://github.com/idealista/redis_role/tree/2.1.5) (2018-02-08)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.4...2.1.5)
 
 ### Added
+
 - *[#36](https://github.com/idealista/redis_role/issues/36) Prevent changing transparent_hugepage for container installations* @lihiwish
 
 ### Fixed
+
 - *[#38](https://github.com/idealista/redis_role/issues/38) Param redis-confs.cluster-config-file is not accessed correctly* @lihiwish
 
 ## [2.1.4](https://github.com/idealista/redis_role/tree/2.1.4) (2018-02-06)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.3...2.1.4)
 
 ### Fixed
+
 - *[#30](https://github.com/idealista/redis_role/issues/30) Read cluster config file name from configuration* @lihiwish
 - *[#32](https://github.com/idealista/redis_role/issues/32) Reading the cluster host IP does not work well when the cluster have several IPs* @lihiwish
 
 ## [2.1.3](https://github.com/idealista/redis_role/tree/2.1.3) (2017-12-21)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.2...2.1.3)
 
 ### Fixed
+
 - *[#25](https://github.com/idealista/redis_role/issues/25) Fix a bug when a master node is removed from cluster during redis version upgrade* @jdvr
 
 ### Added
+
 - *[#26](https://github.com/idealista/redis_role/issues/26) Upgrade molecule version to improve the test and add a requirements.txt* @jdvr
 
 ## [2.1.2](https://github.com/idealista/redis_role/tree/2.1.2) (2017-08-24)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.1...2.1.2)
 
 ### Added
+
 - *[#18](https://github.com/idealista/redis_role/issues/18) Add task to follow redis setup hints* @jdvr
 
 ## [2.1.1](https://github.com/idealista/redis_role/tree/2.1.1) (2017-08-21)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.1.0...2.1.1)
 
 ### Fixed
+
 - *[#16](https://github.com/idealista/redis_role/issues/16) The `redis.conf` file is generated with bad indentation* @jdvr
 - *[#17](https://github.com/idealista/redis_role/issues/17) Create a configurable var for pid file path* @jdvr
 
 ## [2.1.0](https://github.com/idealista/redis_role/tree/2.1.0) (2017-08-17)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.0.1...2.1.0)
 
 ### Added
+
 - *[#8](https://github.com/idealista/redis_role/issues/8) Add `upgrading-helper` script to manage nodes during cluster upgrades* @jdvr
 
 ## [2.0.1](https://github.com/idealista/redis_role/tree/2.0.0) (2017-08-10)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/2.0.0...2.0.1)
 
 ### Fixed
+
 - *[#4](https://github.com/idealista/redis_role/issues/4) Remove redis group from `cluster-creator` script* @jdvr
 - *[#6](https://github.com/idealista/redis_role/issues/6) Check nodes status before create cluster* @jdvr
 
 ## [2.0.0](https://github.com/idealista/redis_role/tree/2.0.0) (2017-08-10)
+
 [Full Changelog](https://github.com/idealista/redis_role/compare/1.0.0...2.0.0)
 
 ### Added
+
 - *[#1](https://github.com/idealista/redis_role/issues/1) Redis cluster (install nodes and configure)* @jdvr
 
 ## [1.0.0](https://github.com/idealista/redis_role/tree/1.0.0) (2017-04-20)
 
 ### Added
+
 - *First release* @jmonterrubio

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: restart redis
-  service:
+  ansible.builtin.service:
     name: redis-server
     state: restarted
 
   when: redis_service_state != 'stopped'
 
 - name: oneshot disable thp
-  systemd:
+  ansible.builtin.systemd:
     name: disable_thp
     state: restarted

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -18,7 +18,9 @@ platforms:
     capabilities:
       - SYS_ADMIN
     volumes:
-      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/cgroup:/sys/fs/cgroup:rw'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+    cgroupns_mode: host
     tmpfs:
       - /redis
       - /tmp

--- a/molecule/single/molecule.yml
+++ b/molecule/single/molecule.yml
@@ -16,7 +16,9 @@ platforms:
     capabilities:
       - SYS_ADMIN
     volumes:
-      - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/cgroup:/sys/fs/cgroup:rw'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+    cgroupns_mode: host
     tmpfs:
       - /redis
       - /tmp

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -16,6 +16,7 @@
   when: redis_auth
 
 - name: REDIS | Verify redis password configuration
+  when: redis_password is defined and redis_auth
   block:
     - name: REDIS | Check password complexity (fail if 'redis_password' is too weak)
       ansible.builtin.assert:
@@ -33,7 +34,6 @@
         redis_confs: "{{ redis_confs | default({}) | combine({'requirepass': redis_password}) }}"
       changed_when: false
       no_log: true
-  when: redis_password is defined and redis_auth
 
 - name: REDIS | Redis already installed
   ansible.builtin.shell: '[ -x "$(command -v redis-server)" ] && echo "True" || echo "False"'

--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: REDIS | Check if redis_auth is defined
-  assert:
+  ansible.builtin.assert:
     that:
       - redis_auth is defined
     quiet: true
     fail_msg: "The redis_auth must be set as a variable (true or false)"
 
 - name: REDIS | Check if password is not set and authentication is enabled
-  assert:
+  ansible.builtin.assert:
     that:
       - redis_password is defined
     quiet: true
@@ -18,7 +18,7 @@
 - name: REDIS | Verify redis password configuration
   block:
     - name: REDIS | Check password complexity (fail if 'redis_password' is too weak)
-      assert:
+      ansible.builtin.assert:
         that:
           - redis_password is defined
           - redis_password | length >= 30
@@ -27,18 +27,19 @@
           - redis_password | regex_search('[0-9]')
         quiet: true
         fail_msg: "The password must be at least 30 characters long and contain at least one uppercase letter, one lowercase letter and one number"
+
     - name: REDIS | Set 'redis_password' if provided
-      set_fact:
-        redis_confs: "{{ redis_confs | default({}) | combine({ 'requirepass': redis_password }) }}"
+      ansible.builtin.set_fact:
+        redis_confs: "{{ redis_confs | default({}) | combine({'requirepass': redis_password}) }}"
       changed_when: false
       no_log: true
   when: redis_password is defined and redis_auth
 
 - name: REDIS | Redis already installed
-  shell: '[ -x "$(command -v redis-server)" ] && echo "True" || echo "False"'
+  ansible.builtin.shell: '[ -x "$(command -v redis-server)" ] && echo "True" || echo "False"'
   register: redis_is_installed_command
   changed_when: false
 
 - name: REDIS | Set installed fact
-  set_fact:
+  ansible.builtin.set_fact:
     redis_is_installed: "{{ redis_is_installed_command.stdout }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: REDIS | Create server conf path
-  file:
+  ansible.builtin.file:
     path: "{{ redis_conf_path }}"
     state: directory
     owner: "{{ redis_user }}"
@@ -9,7 +9,7 @@
     mode: 0755
 
 - name: REDIS | Copy server config
-  template:
+  ansible.builtin.template:
     src: "{{ redis_server_conf_template_path }}"
     dest: "{{ redis_conf_path }}/redis.conf"
     owner: "{{ redis_user }}"
@@ -18,7 +18,7 @@
   notify: restart redis
 
 - name: REDIS | Copy default config
-  copy:
+  ansible.builtin.copy:
     src: "{{ redis_build_path }}/redis.conf"
     dest: "{{ redis_conf_path }}/redis-default.conf"
     mode: 0644
@@ -27,7 +27,7 @@
   when: include_redis_default_conf
 
 - name: REDIS | Copy manager script
-  template:
+  ansible.builtin.template:
     src: "{{ redis_manager_template_path }}"
     dest: "{{ redis_bin_path }}/instance-manager.sh"
     owner: "{{ redis_user }}"
@@ -36,7 +36,7 @@
   notify: restart redis
 
 - name: REDIS | Copy redis-server service config
-  template:
+  ansible.builtin.template:
     src: "{{ redis_service_template_path }}"
     dest: /lib/systemd/system/redis-server.service
     owner: "{{ redis_user }}"
@@ -45,7 +45,7 @@
   notify: restart redis
 
 - name: REDIS | Copy cluster creator
-  template:
+  ansible.builtin.template:
     src: "{{ item }}.j2"
     dest: "{{ redis_conf_path }}/{{ item }}"
     owner: "{{ redis_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: REDIS | Create Redis group
-  group:
+  ansible.builtin.group:
     name: "{{ redis_group }}"
     state: present
   when: not redis_is_installed
 
 - name: REDIS | Create Redis user
-  user:
+  ansible.builtin.user:
     name: "{{ redis_user }}"
     group: "{{ redis_group }}"
     shell: /usr/sbin/nologin
@@ -16,7 +16,7 @@
   when: not redis_is_installed
 
 - name: REDIS | Create log directory
-  file:
+  ansible.builtin.file:
     path: "{{ redis_log_path }}"
     owner: "{{ redis_user }}"
     group: "{{ redis_group }}"
@@ -25,7 +25,7 @@
   when: not redis_is_installed and redis_confs.logfile is defined
 
 - name: REDIS | Create log file
-  file:
+  ansible.builtin.file:
     path: "{{ redis_confs.logfile }}"
     owner: "{{ redis_user }}"
     group: "{{ redis_group }}"
@@ -34,13 +34,13 @@
   when: not redis_is_installed and redis_confs.logfile is defined
 
 - name: REDIS | Remove instance from cluster
-  command: "{{ redis_conf_path }}/upgrading-helper.sh delete"
+  ansible.builtin.command: "{{ redis_conf_path }}/upgrading-helper.sh delete"
   when:
     - redis_install_new_version
     - redis_mode == 'cluster'
 
 - name: REDIS | Stop node
-  service:
+  ansible.builtin.service:
     name: redis-server
     state: stopped
   when:
@@ -48,21 +48,21 @@
     - redis_mode == 'cluster'
 
 - name: REDIS | Remove existing install folder
-  file:
+  ansible.builtin.file:
     state: absent
     path: "{{ redis_build_path }}"
   ignore_errors: true
   when: not redis_is_installed or redis_install_new_version
 
 - name: REDIS | Install required libs
-  apt:
+  ansible.builtin.apt:
     name: "{{ redis_required_libs }}"
     update_cache: true
     state: present
     cache_valid_time: 3600
 
 - name: REDIS | Install cluster required libs
-  apt:
+  ansible.builtin.apt:
     name: "{{ redis_required_libs_cluster }}"
     update_cache: true
     state: present
@@ -70,50 +70,50 @@
   when: redis_mode == 'cluster'
 
 - name: REDIS | Download sources
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ redis_source_url }}"
     dest: /tmp
     validate_certs: no
   when: not redis_is_installed or redis_install_new_version
 
 - name: REDIS | Extract sources
-  unarchive:
+  ansible.builtin.unarchive:
     copy: no
     src: "/tmp/redis-{{ redis_version }}.tar.gz"
     dest: "/tmp"
   when: not redis_is_installed or redis_install_new_version
 
 - name: REDIS | Move sources to build path
-  command: "mv /tmp/redis-{{ redis_version }} {{ redis_build_path }}"
+  ansible.builtin.command: "mv /tmp/redis-{{ redis_version }} {{ redis_build_path }}"
   when: not redis_is_installed or redis_install_new_version
 
 - name: REDIS | Make
-  make:
+  community.general.make:
     chdir: "{{ redis_build_path }}"
   when: not redis_is_installed or redis_install_new_version
 
 - name: REDIS | Make test
-  make:
+  community.general.make:
     chdir: "{{ redis_build_path }}"
     target: test
   when: (not redis_is_installed or redis_install_new_version) and redis_check_build
 
 - name: REDIS | Make install
-  make:
+  community.general.make:
     chdir: "{{ redis_build_path }}"
     target: install
   become: yes
   when: not redis_is_installed or redis_install_new_version
 
 - name: REDIS | install Redis Ruby Gem
-  gem:
+  community.general.gem:
     name: redis
     state: present
     version: "{{ redis_ruby_gem_version }}"
   when: redis_mode == 'cluster' and redis_cluster_legacy
 
 - name: REDIS | install redis-trib (legacy)
-  copy:
+  ansible.builtin.copy:
     src: "{{ redis_build_path }}/src/redis-trib.rb"
     dest: "{{ redis_bin_path }}"
     mode: 0775

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -74,6 +74,7 @@
     url: "{{ redis_source_url }}"
     dest: /tmp
     validate_certs: no
+    mode: '0644'
   when: not redis_is_installed or redis_install_new_version
 
 - name: REDIS | Extract sources

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,27 @@
 ---
 
 - name: REDIS | Check
-  include: check.yml
+  ansible.builtin.include_tasks: check.yml
   tags:
     - check
 
 - name: REDIS | Install
-  include: install.yml
+  ansible.builtin.include_tasks: install.yml
   tags:
     - install
 
 - name: REDIS | Configure
-  include: config.yml
+  ansible.builtin.include_tasks: config.yml
   tags:
     - configure
 
 - name: REDIS | Operating System Configure
-  include: os-config.yml
+  ansible.builtin.include_tasks: os-config.yml
   tags:
     - os-configure
   when: redis_os_tuning
 
 - name: REDIS | Service
-  include: service.yml
+  ansible.builtin.include_tasks: service.yml
   tags:
     - service

--- a/tasks/os-config.yml
+++ b/tasks/os-config.yml
@@ -3,13 +3,13 @@
 #  https://redis.io/topics/admin Redis setup hint
 
 - name: REDIS | Set overcommit on sysctl
-  sysctl:
+  ansible.posix.sysctl:
     name: vm.overcommit_memory
     value: 1
     state: present
 
 - name: REDIS | Add disable Transparent Huge Pages service
-  template:
+  ansible.builtin.template:
     src: disable_thp.service.j2
     dest: /etc/systemd/system/disable_thp.service
     owner: root
@@ -18,7 +18,7 @@
   notify: oneshot disable thp
 
 - name: REDIS | Add disable Transparent Huge Pages script
-  copy:
+  ansible.builtin.copy:
     src: disable_thp.sh
     dest: /usr/local/bin/disable_thp.sh
     owner: root
@@ -28,7 +28,7 @@
   notify: oneshot disable thp
 
 - name: REDIS | Enable disable Transparent Huge Pages service
-  systemd:
+  ansible.builtin.systemd:
     name: disable_thp
     state: started
     enabled: true

--- a/tasks/os-config.yml
+++ b/tasks/os-config.yml
@@ -14,6 +14,7 @@
     dest: /etc/systemd/system/disable_thp.service
     owner: root
     group: root
+    mode: '0644'
     backup: false
   notify: oneshot disable thp
 

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: REDIS | Configuring service
-  systemd:
+  ansible.builtin.systemd:
     name: redis-server
     state: "{{ redis_service_state }}"
     enabled: "{{ redis_service_enabled }}"
@@ -10,7 +10,7 @@
 
 - name: REDIS | Configure nodes as cluster
   run_once: true
-  command: "{{ redis_conf_path }}/cluster-creator.sh"
+  ansible.builtin.command: "{{ redis_conf_path }}/cluster-creator.sh"
   environment:
     REDISCLI_AUTH: "{{ redis_password }}"
   when:
@@ -20,21 +20,21 @@
 
 - name: REDIS | Configure nodes as cluster without password
   run_once: true
-  command: "{{ redis_conf_path }}/cluster-creator.sh"
+  ansible.builtin.command: "{{ redis_conf_path }}/cluster-creator.sh"
   when:
     - redis_mode == 'cluster'
     - not redis_is_installed
     - not redis_auth
 
 - name: REDIS | Add instance to cluster without password
-  command: "{{ redis_conf_path }}/upgrading-helper.sh add"
+  ansible.builtin.command: "{{ redis_conf_path }}/upgrading-helper.sh add"
   when:
     - redis_install_new_version
     - redis_mode == 'cluster'
     - not redis_auth
 
 - name: REDIS | Add instance to cluster with password
-  command: "{{ redis_conf_path }}/upgrading-helper.sh add"
+  ansible.builtin.command: "{{ redis_conf_path }}/upgrading-helper.sh add"
   environment:
     REDISCLI_AUTH: "{{ redis_password }}"
   when:


### PR DESCRIPTION
### Description of the Change

- Refactor Ansible tasks to use fully qualified module names
- Moved block when to the top of the block
- Set file mode to '0644' for tasks
- Update .gitignore to include additional rules for various IDEs and environments
- Add custom rules for test directories and cache files

### Benefits

Use of FQCN names in tasks to add clarity and enhanced compatibility with newer ansible versions requiring to use FQCN

### Possible Drawbacks

Incompatibility with older versions? Not known

### Applicable Issues

Close #117 